### PR TITLE
fix(SunAsteriskLaravel): exclude "missing variable" in database/factories

### DIFF
--- a/SunAsteriskLaravel/ruleset.xml
+++ b/SunAsteriskLaravel/ruleset.xml
@@ -41,6 +41,9 @@
             </property>
         </properties>
     </rule>
+    <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.MissingVariable">
+        <exclude-pattern>database/factories</exclude-pattern>
+    </rule>
 
     <!-- Migrations classes are different from file names -->
     <rule ref="Squiz.Classes.ClassFileName">


### PR DESCRIPTION
Currently, `/** @var \Illuminate\Database\Eloquent\Factory  */` will be detected as error in Laravel's factory files. It should be excluded from the Laravel project.

This PR will exclude `SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.MissingVariable` in 
 `database/factories` folder of `SunAsteriskLaravel` ruleset.